### PR TITLE
Typo in variable name: preliminat_path --> preliminary_path

### DIFF
--- a/src/extract_features.py
+++ b/src/extract_features.py
@@ -8,7 +8,7 @@ import os
 threshold=100
 random.seed(2018)
 def pre_data(final_path=None,preliminary_path=None):
-    if final_path is None and preliminat_path is None:
+    if final_path is None and preliminary_path is None:
         raise "data path is invaild"
     elif final_path is None:
         raise "final data path is invalid"


### PR DESCRIPTION
flake8 testing of https://github.com/guoday/Tencent2018_Lookalike_Rank7th on Python 3.6.3

$ __flake8 . --count --select=E901,E999,F821,F822,F823 --show-source --statistics__
```
./models/base_model.py:13:25: F821 undefined name 'iterator'
        self.iterator = iterator
                        ^
./src/extract_features.py:11:31: F821 undefined name 'preliminat_path'
    if final_path is None and preliminat_path is None:
                              ^
2     F821 undefined name 'iterator'
2
```